### PR TITLE
[BUG] Crash when resizing a board in the editor

### DIFF
--- a/pgl-editor.py
+++ b/pgl-editor.py
@@ -1135,6 +1135,11 @@ while True:
                                 model=game.current_board().ui_board_void_cell
                             )
                         )
+                        game.current_board()._overlapped_matrix[x].append(
+                            board_items.BoardItemVoid(
+                                model=game.current_board().ui_board_void_cell
+                            )
+                        )
                         is_modified = True
 
         elif key == "2":
@@ -1143,6 +1148,7 @@ while True:
             if nw >= game.current_board().size[1]:
                 old_value = game.current_board().size[1]
                 game.current_board().size[1] = nw
+                # TODO: We should use list completion here
                 for x in range(old_value, nw, 1):
                     new_array = []
                     for y in range(0, game.current_board().size[0], 1):
@@ -1152,6 +1158,8 @@ while True:
                             )
                         )
                     game.current_board()._matrix.append(new_array)
+                    # TODO: Need to test side effects
+                    game.current_board()._overlapped_matrix.append(deepcopy(new_array))
                     is_modified = True
 
         elif key == "3":


### PR DESCRIPTION
# Pull Request Template

## Description

Correct the issue with the editor crashing when resizing a board.

Fixes #106

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Coverage tests
- [x] Functional tests

**Test Configuration**:
* OS: Fedora Linux
* OS version: 31
* Python version: 3.7.9
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
