### PR TITLE
Add code coverage for the sprixel support in _obj2ref and _ref2obj.

### DIFF
--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -2,6 +2,7 @@ from pygamelib import engine
 from pygamelib import base
 from pygamelib import board_items
 from pygamelib import constants
+from pygamelib.gfx import core
 import unittest
 
 # Test cases for all classes in pygamelib.gfx.core except for Animation.
@@ -242,6 +243,15 @@ class TestBase(unittest.TestCase):
                 board_items.GenericActionableStructure(value=10, inventory_space=1),
                 1,
                 5,
+            )
+        )
+        self.assertIsNone(
+            b.place_item(
+                board_items.Door(
+                    value=10, inventory_space=1, sprixel=core.Sprixel("#")
+                ),
+                2,
+                2,
             )
         )
         self.assertIsNone(


### PR DESCRIPTION
# Pull Request Template

## Description

Add coverage for the export/load of sprixels in board.

Fixes #126 

## Type of change

Please delete options that are not relevant.

- [x] Update test cases/coverage.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `make coverage`

**Test Configuration**:
* OS: Fedora Linux
* OS version: 31
* Python version: 3.7.9
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
