### PR TITLE
Add the possibility to generate a random color in the color editor

### DIFF
--- a/pgl-editor.py
+++ b/pgl-editor.py
@@ -137,6 +137,7 @@ def custom_color_picker():
         print("5/2 - Increase/decrease the green value")
         print("6/3 - Increase/decrease the blue value")
         print(f"+/- - Increase/decrease the increment step (current: {step})")
+        print("r - Randomize values")
         key = game.get_key()
         if key == "1" and spr.bg_color.r >= step:
             spr.bg_color.r -= step
@@ -154,6 +155,8 @@ def custom_color_picker():
             step -= 1
         elif key == "+":
             step += 1
+        elif key == "r":
+            spr.bg_color.randomize()
     return spr
 
 

--- a/pygamelib/gfx/core.py
+++ b/pygamelib/gfx/core.py
@@ -15,6 +15,7 @@ from pygamelib import base
 from pygamelib import constants
 from pygamelib.assets import graphics
 from pygamelib.functions import pgl_isinstance
+import random
 import time
 from collections import UserDict
 from uuid import uuid4
@@ -280,6 +281,21 @@ class Color(object):
                     f"In Color.load(data) the {c} component is not an integer."
                 )
         return cls(data["red"], data["green"], data["blue"])
+
+    def randomize(self):
+        """Set a random value for each component
+
+        :returns: None
+        :rtype: NoneType
+
+        Example::
+
+            color = Color()
+            color.randomize()
+        """
+        self.r = random.randrange(256)
+        self.g = random.randrange(256)
+        self.b = random.randrange(256)
 
 
 class Sprixel(object):

--- a/tests/test_gfx_core_color.py
+++ b/tests/test_gfx_core_color.py
@@ -78,6 +78,21 @@ class TestBase(unittest.TestCase):
         with self.assertRaises(gfx_core.base.PglInvalidTypeException):
             gfx_core.Color.load({"red": 25, "green": "nope"})
 
+    def test_color_randomize(self):
+        # Let's keep this simple: most often than not,
+        # the randomized value should be different from the default one
+        # and the previous one
+        default_color = gfx_core.Color()
+        c = gfx_core.Color()
+        criteria_match_count = 0
+        total_rolls = 100
+        for i in range(total_rolls):
+            previous_color = gfx_core.Color(c.r, c.g, c.b)
+            c.randomize()
+            if c != default_color and c != previous_color:
+                criteria_match_count += 1
+        self.assertGreater(criteria_match_count, total_rolls // 2)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Using the Pull Request Template

## Description

Add the possibility to generate a random color in the color editor as specified in the related issue and a unit test.
No new dependencies.

Fixes #141 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] python -m unittest discover -s tests
- [x] manual test:
  - 3 - edit hac-maps/test_editor.json
  - c - Create new item / Structure / 4 - New generic object / name: wellwellwell / type: structure / Model type: 1 - colored squares and rectangles / 0 - custom color / 1 - rectangle / r - Randomize / pickable: yes, overlappable: no


**Test Configuration**: 
* OS: Linux Mint
* OS version: 18.3
* Python version: 3.7.9
* Architecture: x86_64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the docstrings
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
