### PR TITLE
Make dev env setup a bit easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ clean:
 	find ./ -iname '__pycache__' | xargs rm -rf
 	(cd docs && make clean)
 
+devenv:
+	pip3 install --user pipenv
+	pipenv install --dev
+
 all: coverage doc clean pp
 
 .PHONY: tpp pp test clean doc

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ It will pull all dependencies
 ### Python
 
 The pygamelib only supports Python 3.6+. It will **not** run with Python 2.
+Python 3.10 or later is not yet supported, due to a dependency on numpy 1.20.3.
 We use [pipenv](https://github.com/pypa/pipenv) to manage dependencies.
 
 Run Pipenv to install the requirements:
@@ -90,6 +91,8 @@ If you want the development dependencies you need to run:
 pip3 install pipenv
 pipenv install --dev
 ```
+
+Or you can just run ```make devenv``` if make is available on your system.
 
 ### Runing tests 
 


### PR DESCRIPTION
# Make dev env setup a bit easier

## Description

Add a _devenv_ target to the Makefile
Readme: Python 3.10 can't be supported because of numpy.

## Type of change

[x] Developer environment improvement

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Check out project, open in a 3.9 (not 3.10!) Python remote container using VSCode, make devenv, make test

* OS: Debian
* OS version: 11.1
* Python version: 3.9
* Architecture: x64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
