### PR TITLE
Fix assertRaises exception usages

### DIFF
--- a/tests/test_actuators.py
+++ b/tests/test_actuators.py
@@ -128,17 +128,17 @@ class TestBase(unittest.TestCase):
         npc.actuator.actuated_object = None
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.find_path()
-            self.assertEqual(e.error, "actuated_object is not defined")
+        self.assertEqual(e.exception.error, "actuated_object is not defined")
         npc.actuator.actuated_object = board_items.Door()
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.find_path()
-            self.assertEqual(e.error, "actuated_object not a Movable object")
+        self.assertEqual(e.exception.error, "actuated_object not a Movable object")
         npc.actuator.actuated_object = board_items.Door()
         npc.actuator.actuated_object = npc
         npc.actuator.destination = None
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.find_path()
-            self.assertEqual(e.error, "destination is not defined")
+        self.assertEqual(e.exception.error, "destination is not defined")
         b.place_item(board_items.Wall(), 2, 2)
         npc.actuator.set_destination(2, 2)
         self.assertEqual(npc.actuator.find_path(), [])
@@ -182,7 +182,7 @@ class TestBase(unittest.TestCase):
             npc.actuator.remove_waypoint("10", 10)
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.remove_waypoint(30, 30)
-            self.assertEqual(e.error, "invalid_waypoint")
+        self.assertEqual(e.exception.error, "invalid_waypoint")
         self.assertIsNone(npc.actuator.remove_waypoint(10, 10))
 
     def test_pathfinder_astar(self):
@@ -213,16 +213,16 @@ class TestBase(unittest.TestCase):
         npc.actuator.actuated_object = None
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.find_path()
-            self.assertEqual(e.error, "actuated_object is not defined")
+        self.assertEqual(e.exception.error, "actuated_object is not defined")
         npc.actuator.actuated_object = board_items.Door()
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.find_path()
-            self.assertEqual(e.error, "actuated_object not a Movable object")
+        self.assertEqual(e.exception.error, "actuated_object not a Movable object")
         npc.actuator.actuated_object = npc
         npc.actuator.destination = None
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.find_path()
-            self.assertEqual(e.error, "destination is not defined")
+        self.assertEqual(e.exception.error, "destination is not defined")
         b.place_item(board_items.Wall(), 2, 2)
         npc.actuator.set_destination(2, 2)
         self.assertEqual(npc.actuator.find_path(), [])
@@ -266,7 +266,7 @@ class TestBase(unittest.TestCase):
             npc.actuator.remove_waypoint("10", 10)
         with self.assertRaises(engine.base.PglException) as e:
             npc.actuator.remove_waypoint(30, 30)
-            self.assertEqual(e.error, "invalid_waypoint")
+        self.assertEqual(e.exception.error, "invalid_waypoint")
         self.assertIsNone(npc.actuator.remove_waypoint(10, 10))
 
     def test_pathfinder_serialization(self):

--- a/tests/test_board.py
+++ b/tests/test_board.py
@@ -206,7 +206,7 @@ class TestBoard(unittest.TestCase):
         j.store_position(2, 2)
         with self.assertRaises(pgl_base.PglException) as e:
             self.board.remove_item(j)
-            self.assertEqual(e.error, "invalid_item")
+        self.assertEqual(e.exception.error, "invalid_item")
         self.assertTrue(self.board.remove_item(i))
         b = pgl_engine.Board()
         i = pgl_board_items.ComplexNPC(

--- a/tests/test_boardItem.py
+++ b/tests/test_boardItem.py
@@ -148,7 +148,7 @@ class TestBoard(unittest.TestCase):
     def test_projectile(self):
         with self.assertRaises(board_items.base.PglException) as e:
             board_items.Projectile(range=6, step=4)
-            self.assertEqual(e.error, "incorrect_range_step")
+        self.assertEqual(e.exception.error, "incorrect_range_step")
         p = board_items.Projectile()
         self.assertFalse(p.has_inventory())
         self.assertTrue(p.overlappable())

--- a/tests/test_engine_inventory.py
+++ b/tests/test_engine_inventory.py
@@ -46,11 +46,11 @@ class TestBase(unittest.TestCase):
         self.assertEqual(self.inv.get_item("test").name, "test")
         with self.assertRaises(engine.base.PglInventoryException) as e:
             self.inv.get_item("crash")
-            self.assertEqual(e.error, "no_item_by_that_name")
+        self.assertEqual(e.exception.error, "no_item_by_that_name")
         self.assertIsNone(self.inv.delete_item("test"))
         with self.assertRaises(engine.base.PglInventoryException) as e:
             self.inv.delete_item("test")
-            self.assertEqual(e.error, "no_item_by_that_name")
+        self.assertEqual(e.exception.error, "no_item_by_that_name")
 
     def test_str(self):
         self.inv.empty()

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -60,7 +60,7 @@ class TestBase(unittest.TestCase):
         )
         with self.assertRaises(base.PglException) as e:
             game.display_menu("main_menu_bork")
-            self.assertEqual(e.error, "invalid_menu_category")
+        self.assertEqual(e.exception.error, "invalid_menu_category")
         self.assertIsNone(game.clear_screen())
 
     def test_config(self):
@@ -77,7 +77,7 @@ class TestBase(unittest.TestCase):
             g.save_config("high_scores", None)
         with self.assertRaises(base.PglException) as e:
             g.save_config("Unknown", "test-pygamelib.engine.Game.config.json")
-            self.assertEqual(e.error, "unknown section")
+        self.assertEqual(e.exception.error, "unknown section")
         # Don't do that...
         g._configuration = None
         g._configuration_internals = None
@@ -108,7 +108,7 @@ class TestBase(unittest.TestCase):
             g.current_board()
         with self.assertRaises(base.PglException) as e:
             g.change_level(1)
-            self.assertEqual(e.error, "undefined_player")
+        self.assertEqual(e.exception.error, "undefined_player")
         g.player = board_items.Player()
         self.assertIsNone(g.change_level(1))
         self.assertIsNone(g.add_board(2, engine.Board()))

--- a/tests/test_gfx_core_sprite.py
+++ b/tests/test_gfx_core_sprite.py
@@ -19,16 +19,16 @@ class TestBase(unittest.TestCase):
             spr.sprixel(1, "crash")
         with self.assertRaises(gfx_core.base.PglException) as e:
             spr.sprixel(1, 10)
-            self.assertEqual(e.error, "out_of_sprite_boundaries")
+        self.assertEqual(e.exception.error, "out_of_sprite_boundaries")
         self.assertTrue(type(spr.sprixel(1)) is list)
         with self.assertRaises(gfx_core.base.PglException) as e:
             spr.sprixel(10, 1)
-            self.assertEqual(e.error, "out_of_sprite_boundaries")
+        self.assertEqual(e.exception.error, "out_of_sprite_boundaries")
         with self.assertRaises(gfx_core.base.PglInvalidTypeException):
             spr.set_sprixel(1, "crash", "bork")
         with self.assertRaises(gfx_core.base.PglException) as e:
             spr.set_sprixel(1, 10, "bork")
-            self.assertEqual(e.error, "out_of_sprite_boundaries")
+        self.assertEqual(e.exception.error, "out_of_sprite_boundaries")
         with self.assertRaises(gfx_core.base.PglInvalidTypeException):
             spr.set_sprixel(1, 1, "bork")
 
@@ -132,7 +132,7 @@ class TestBase(unittest.TestCase):
     def test_load(self):
         with self.assertRaises(gfx_core.base.PglException) as e:
             gfx_core.Sprite.load_from_ansi_file("tests/house-red-borked.ans")
-            self.assertEqual(e.error, "sprite_file_format_not_supported")
+        self.assertEqual(e.exception.error, "sprite_file_format_not_supported")
         spr = gfx_core.Sprite.load_from_ansi_file("tests/house-red-double.ans")
         self.assertEqual(spr.width, 17)
         gfx_core.Sprite.load_from_ansi_file("tests/house-red.ans")
@@ -179,7 +179,7 @@ class TestBase(unittest.TestCase):
                     ],
                 }
             )
-            self.assertEqual(e.error, "invalid_sprite_size")
+        self.assertEqual(e.exception.error, "invalid_sprite_size")
 
     def test_collection(self):
         spr = gfx_core.Sprite(
@@ -218,10 +218,10 @@ class TestBase(unittest.TestCase):
         self.assertEqual(spr3.sprixel(1, 1), sc2.get(spr3.name).sprixel(1, 1))
         with self.assertRaises(gfx_core.base.PglException) as e:
             gfx_core.SpriteCollection.load({})
-            self.assertEqual(e.error, "invalid_sprite_data")
+        self.assertEqual(e.exception.error, "invalid_sprite_data")
         with self.assertRaises(gfx_core.base.PglException) as e:
             gfx_core.SpriteCollection.load({"sprites_count": 2, "sprites": {}})
-            self.assertEqual(e.error, "corrupted_sprite_data")
+        self.assertEqual(e.exception.error, "corrupted_sprite_data")
 
     def test_scale(self):
         spr = gfx_core.Sprite(


### PR DESCRIPTION
# Fix assertRaises exception usages

## Description

If assertRaises is used in a _with_ context, it will return a context manager, not the exception. The linter marked the e.error lines but why was there no AttributeError? Simply because the _self.assertEqual(e.error, ..._ lines were never executed because they were inside the context-managed code block, following the expected exception.

## Type of change

- [x] Test fix (non-breaking change)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] make test

**Test Configuration**:
* OS: Debian
* OS version: 11.1
* Python version: 3.9.7
* Architecture: x64

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
